### PR TITLE
Atualiza serviço para atuar na pasta pai

### DIFF
--- a/AtualizaAPP/Utils/FileUtils.cs
+++ b/AtualizaAPP/Utils/FileUtils.cs
@@ -14,7 +14,7 @@ namespace AtualizaAPP.Utils
             Directory.CreateDirectory(dir);
         }
 
-        public static void CopyDirectory(string sourceDir, string destDir, HashSet<string>? excludeFileNames = null)
+        public static void CopyDirectory(string sourceDir, string destDir, HashSet<string>? excludeFileNames = null, HashSet<string>? excludeDirNames = null)
         {
             var src = new DirectoryInfo(sourceDir);
             if (!src.Exists) throw new DirectoryNotFoundException(sourceDir);
@@ -28,8 +28,9 @@ namespace AtualizaAPP.Utils
             }
             foreach (var sub in src.GetDirectories())
             {
+                if (excludeDirNames != null && excludeDirNames.Contains(sub.Name)) continue;
                 var destSub = Path.Combine(destDir, sub.Name);
-                CopyDirectory(sub.FullName, destSub, excludeFileNames);
+                CopyDirectory(sub.FullName, destSub, excludeFileNames, excludeDirNames);
             }
         }
 


### PR DESCRIPTION
## Summary
- atualiza `UpdaterService` para usar a pasta acima como diretório de instalação e ignorar a pasta AtualizaAPP
- permite excluir diretórios ao copiar arquivos e protege a pasta do atualizador em backup/restauração
- ajusta aplicação e limpeza para não remover arquivos dentro de `AtualizaAPP`

## Testing
- `dotnet build` *(falhou: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_68bb11c0194c8333aaac0acd8a921947