### PR TITLE
Preserve config files during purge

### DIFF
--- a/AtualizaAPP/Services/UpdaterService.cs
+++ b/AtualizaAPP/Services/UpdaterService.cs
@@ -381,8 +381,16 @@ namespace AtualizaAPP.Services
 
         private void PurgeObsolete(string fromDir)
         {
-            var excludeFiles = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase) { ThisExeName };
-            var excludeDirs = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase) { UpdaterDirName };
+            // Preserve the same essential files and folders used during the initial cleaning
+            var excludeFiles = new System.Collections.Generic.HashSet<string>(_excludeFileNamesRoot, StringComparer.OrdinalIgnoreCase)
+            {
+                ThisExeName
+            };
+            var excludeDirs = new System.Collections.Generic.HashSet<string>(_excludeDirNamesRoot, StringComparer.OrdinalIgnoreCase)
+            {
+                UpdaterDirName
+            };
+
             var newSet = Directory.EnumerateFiles(fromDir, "*", SearchOption.AllDirectories)
                                   .Select(p => Path.GetRelativePath(fromDir, p))
                                   .ToHashSet(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary
- Keep configuration and backup files when purging obsolete files after an update

## Testing
- `dotnet build` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb22aea8848333990ab8d2a287b1dc