### PR TITLE
Auto open LeituraWPF after success

### DIFF
--- a/AtualizaAPP/SuccessWindow.xaml
+++ b/AtualizaAPP/SuccessWindow.xaml
@@ -32,7 +32,6 @@
 
         <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="OpenTargetBtn" Content="Abrir LeituraWPF" Click="OpenTargetBtn_Click"/>
-            <Button Content="Fechar" Margin="8,0,0,0" Click="CloseBtn_Click"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/AtualizaAPP/SuccessWindow.xaml.cs
+++ b/AtualizaAPP/SuccessWindow.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.ComponentModel;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace AtualizaAPP
@@ -6,6 +8,7 @@ namespace AtualizaAPP
     public partial class SuccessWindow : Window
     {
         private readonly Action _onOpenTarget;
+        private bool _opened;
 
         public SuccessWindow(Version oldVersion, Version newVersion, Action? onOpenTarget = null)
         {
@@ -13,14 +16,41 @@ namespace AtualizaAPP
             OldVersionText.Text = $"v{oldVersion}";
             NewVersionText.Text = $"v{newVersion}";
             _onOpenTarget = onOpenTarget ?? (() => { });
+            Loaded += SuccessWindow_Loaded;
+        }
+
+        private async void SuccessWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30));
+            if (!_opened)
+            {
+                OpenTarget();
+                Close();
+            }
         }
 
         private void OpenTargetBtn_Click(object sender, RoutedEventArgs e)
         {
+            OpenTarget();
+            Close();
+        }
+
+        private void OpenTarget()
+        {
+            if (_opened) return;
+            _opened = true;
             try { _onOpenTarget(); }
             catch { /* ignore */ }
         }
 
-        private void CloseBtn_Click(object sender, RoutedEventArgs e) => Close();
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            if (!_opened)
+            {
+                OpenTarget();
+            }
+            base.OnClosing(e);
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- Launch LeituraWPF automatically after 30 seconds on the success screen or when the window is closed
- Remove explicit close button from the success window

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2584f5b883339ee3b66adffcac1e